### PR TITLE
SRE-3333 Support multiple domains in a fastly service

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Once you have the `terraform-fastly-service` you need to provide the correct `cr
 
 ```
  export FASTLY_API_KEY="my-fastly-api-key-xxx"
- export AWS_REGION="eu-central-1"
+ export AWS_REGION="my-aws-region"
  export AWS_ACCESS_KEY_ID="my-aws-access-key-id-xxx"
  export AWS_SECRET_ACCESS_KEY="my-aws-secret-access-key-xxx"
  export AWS_SESSION_TOKEN="my-aws-session-token-xxx"
@@ -47,7 +47,7 @@ given the examples in [use cases examples](./use_case_examples/)
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| domain | Internet facing CDN domain | string | "" | yes |
+| domains | Internet facing CDN domains for fastly service | list | [] | yes |
 | service_name       | Fastly service name | string | "" | yes | 
 | director           | Backend's group director declaration. [Ref: director](https://developer.fastly.com/reference/api/load-balancing/directors/director/) | bool | false |  no |
 | number_of_backends | The port number on which the backends respond | number | 1 | yes |

--- a/aws.tf
+++ b/aws.tf
@@ -6,15 +6,18 @@ resource "fastly_tls_subscription" "service" {
 }
 
 data "fastly_tls_configuration" "service" {
-  id    = fastly_tls_subscription.service.configuration_id
+  id = fastly_tls_subscription.service.configuration_id
 }
 
 data "aws_route53_zone" "magnolia_cloud_hosted_zone" {
-  name  = regex("\\.(.*)", var.domain)[0]
+  name = regex("\\.(.*)", var.domains[0])[0]
 }
 
 resource "aws_route53_record" "service" {
-  name    = var.domain
+
+  for_each = toset(var.domains)
+
+  name    = each.value
   type    = var.aws_route_53_record["type"]
   zone_id = data.aws_route53_zone.magnolia_cloud_hosted_zone.id
   records = [for dns_record in data.fastly_tls_configuration.service.dns_records : dns_record.record_value if dns_record.record_type == "CNAME"]

--- a/examples/README.md
+++ b/examples/README.md
@@ -36,7 +36,7 @@ In order to update our simple `fastly service` without TLS and provide `TLS feat
 `terraform-fastly-service` in the following way:
 
 ```
-domain = "myawesome-test.exp.magnolia-cloud.com"
+domains = ["myawesome-test.exp.magnolia-cloud.com"]
 
 service_name       = "magnolia-cloud-myawesome-test-staging"
 backend_address    = "myawesome-test.s3.eu-central-1.amazonaws.com"
@@ -87,7 +87,7 @@ Let's check that the AWS Route53 records were created automatically too
    ![alt text](../images/11.uce-2-route53recordsadded.png)
    
 Once the records and the validation has been created in `Fastly` we will see the `TLS` for our `fastly service` activated
-with the domain specified
+with the domains specified
 
    ![alt text](../images/12.uce-2-fastlyservicetlsdone.png)
 
@@ -121,7 +121,7 @@ To configure the `terraform-fastly-service` to provide the desired behaviour ([k
 we can do it through a following snippet:
 
 ```
-domain = "myawesome-test.exp.magnolia-cloud.com"
+domains = ["myawesome-test.exp.magnolia-cloud.com"]
 
 service_name       = "magnolia-cloud-myawesome-test-staging"
 backend_address    = "myawesome-test.s3.eu-central-1.amazonaws.com"
@@ -213,7 +213,7 @@ If we check the current `fastly service` created, we are going to see that this 
 So once requested the `Image Optimizer` feature from Fastly we can set it in config. 
 
 ```
-domain = "myawesome-test.exp.magnolia-cloud.com"
+domain = ["myawesome-test.exp.magnolia-cloud.com"]
 
 service_name       = "magnolia-cloud-myawesome-test-staging"
 #To enable director feature
@@ -289,7 +289,7 @@ for **Datadog** in order to push logs and related information. The important par
 `token` and `region` in the `login_datadog` variable object:
 
 ```
-domain = "myawesome-test.exp.magnolia-cloud.com"
+domains = ["myawesome-test.exp.magnolia-cloud.com"]
 
 service_name       = "magnolia-cloud-myawesome-test-staging"
 backend_address    = "myawesome-test.s3.eu-central-1.amazonaws.com"

--- a/examples/fastly_service_tls/tls.tfvars
+++ b/examples/fastly_service_tls/tls.tfvars
@@ -1,4 +1,4 @@
-domain = "myawesome-test.exp.magnolia-cloud.com"
+domains = ["myawesome-test.exp.magnolia-cloud.com","curra.exp.magnolia-cloud.com"]
 
 service_name       = "magnolia-cloud-myawesome-test-staging"
 backend_address    = "myawesome-test.s3.eu-central-1.amazonaws.com"

--- a/examples/fastly_service_tls_shielding_director/shielding_director.tfvars
+++ b/examples/fastly_service_tls_shielding_director/shielding_director.tfvars
@@ -1,4 +1,4 @@
-domain = "myawesome-test.exp.magnolia-cloud.com"
+domains = ["myawesome-test.exp.magnolia-cloud.com"]
 
 service_name       = "magnolia-cloud-myawesome-test-staging"
 #To enable director feature

--- a/examples/fastly_service_tls_snippets/snippets.tfvars
+++ b/examples/fastly_service_tls_snippets/snippets.tfvars
@@ -1,4 +1,4 @@
-domain = "myawesome-test.exp.magnolia-cloud.com"
+domains = ["myawesome-test.exp.magnolia-cloud.com"]
 
 service_name       = "magnolia-cloud-myawesome-test-staging"
 backend_address    = "myawesome-test.s3.eu-central-1.amazonaws.com"

--- a/examples/fastly_service_tls_snippets_datadog/snippets_datadog.tfvars
+++ b/examples/fastly_service_tls_snippets_datadog/snippets_datadog.tfvars
@@ -1,4 +1,4 @@
-domain = "myawesome-test.exp.magnolia-cloud.com"
+domains = ["myawesome-test.exp.magnolia-cloud.com"]
 
 service_name       = "magnolia-cloud-myawesome-test-staging"
 backend_address    = "myawesome-test.s3.eu-central-1.amazonaws.com"

--- a/fastly.tf
+++ b/fastly.tf
@@ -1,5 +1,5 @@
 locals {
-  host     = regex("[^\\.]*", var.domain)
+  host     = regex("[^\\.]*", var.domains[0])
   backends = [for i in range(0, var.number_of_backends) : "backend_${i}"]
   director = var.director ? toset(formatlist(local.host)) : []
 }
@@ -42,9 +42,13 @@ resource "fastly_service_vcl" "service" {
     }
   }
 
-  domain {
-    name    = var.domain
-    comment = "${var.domain} service domain"
+  dynamic "domain" {
+    for_each = var.domains
+
+    content {
+      name    = domain.value
+      comment = "${domain.value} service domain"
+    }
   }
 
   dynamic "request_setting" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,9 +1,9 @@
 output "cdn_url" {
   description = "The internet-facing endpoint created for the fastly service created"
-  value = "https://${var.domain}"
+  value       = formatlist("https://%s", tolist(var.domains))
 }
 
 output "service_id" {
   description = "The fastly service identifier created"
-  value = fastly_service_vcl.service.id
+  value       = fastly_service_vcl.service.id
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,7 @@
-variable "domain" {
-  type        = string
-  description = "Fastly service domain"
+variable "domains" {
+  type        = list(string)
+  description = "Fastly service domains"
+  default     = []
 }
 
 variable "service_name" {
@@ -83,32 +84,32 @@ variable "shield" {
 
 variable "snippets" {
   description = "VCL snippet's list configured for the service. Ref t.ly/vX8c"
-  type        = list(object({
-      name     = string
-      type     = string
-      priority = number
-      content  = string
-    }))
-  default     = []
+  type = list(object({
+    name     = string
+    type     = string
+    priority = number
+    content  = string
+  }))
+  default = []
 }
 
 variable "request_settings" {
   description = "Settings used to customize Fastly's request in the exposed service handling. Ref: t.ly/gsyr"
-  type        = list(object({
-      name      = string
-      force_ssl = bool
-    }))
-  default     = []
+  type = list(object({
+    name      = string
+    force_ssl = bool
+  }))
+  default = []
 }
 
 variable "logging_datadog" {
   description = "Datadog configuration for fastly service monitoring integration for pushing logs if needed"
-  type        = list(object({
-      name   = string
-      token  = string
-      region = string
-    }))
-  default     = []
+  type = list(object({
+    name   = string
+    token  = string
+    region = string
+  }))
+  default = []
 }
 
 variable "service_force_destroy" {
@@ -137,18 +138,18 @@ variable "tls_force_destroy" {
 
 variable "aws_route_53_record" {
   description = "AWS record configuration for TLS fastly service"
-  type        = object({
-      type = string
-      ttl  = number
-    })
-  default     = null
+  type = object({
+    type = string
+    ttl  = number
+  })
+  default = null
 }
 
 variable "aws_route_53_validation" {
   description = "TLS validation in AWS for fastly service"
-  type        = object({
-      allow_overwrite = bool
-      ttl             = number
-    })
-  default     = null
+  type = object({
+    allow_overwrite = bool
+    ttl             = number
+  })
+  default = null
 }


### PR DESCRIPTION
Provides support configuration to create a fastly service with **multiple domains** use case. 
Has been updated the module, examples and README files.

It has been tested against experimental account and works as expected:

**TF variable configuration**
`domains = ["myawesome-test.exp.magnolia-cloud.com","curra.exp.magnolia-cloud.com"]`

**Overview in fastly service**
![image](https://user-images.githubusercontent.com/1401544/175936785-e05fed29-03cb-4d5e-9040-79b8f0c2d1f8.png)

**TLS validation**
![image](https://user-images.githubusercontent.com/1401544/175936942-7db1725b-36a1-438d-9cae-20888ccba6e8.png)

**Route53 Records**
![image](https://user-images.githubusercontent.com/1401544/175937019-5d94f91a-a2b6-45ea-b305-73145ee99146.png)




